### PR TITLE
Swap Cilium BGP Node/Router ASNs

### DIFF
--- a/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
@@ -65,11 +65,11 @@ spec:
     matchLabels:
       kubernetes.io/os: linux
   bgpInstances:
-    - name: instance-#{ cilium_bgp_router_asn }#
-      localASN: #{ cilium_bgp_router_asn }#
+    - name: instance-#{ cilium_bgp_node_asn }#
+      localASN: #{ cilium_bgp_node_asn }#
       peers:
-        - name: peer-#{ cilium_bgp_node_asn }#-v4
-          peerASN: #{ cilium_bgp_node_asn }#
+        - name: peer-#{ cilium_bgp_router_asn }#-v4
+          peerASN: #{ cilium_bgp_router_asn }#
           peerAddress: #{ cilium_bgp_router_addr }#
           peerConfigRef:
             name: bgp-peer-config-v4


### PR DESCRIPTION
The Cilium BGP node and router ASNs we're swapped in #1855 suggestion. I began seeing "as number mismatch" errors in the cilium-agent logs after adoption of that change. Swapping these assignments allowed BGP peering to correctly be established.

```
cilium-thkmp cilium-agent time="2025-04-22T15:22:44.84449563Z" level=warning msg="sent notification" Data="as number mismatch expected 64514, received 64513" Key=10.0.0.1 Topic=Peer asn=64513 component=gobgp.BgpServerInstance subsys=bgp-control-plane

$ cilium bgp peers
Node     Local AS   Peer AS   Peer Address   Session State   Uptime   Family         Received   Advertised
node01   64513      64514     10.0.0.1       active          0s       ipv4/unicast   0          0

$ grep "^cilium_bgp_node_asn\|cilium_bgp_router_asn" cluster.yaml 
cilium_bgp_router_asn: "64513"
cilium_bgp_node_asn: "64514"

$ git diff networks.yaml
diff --git a/kubernetes/apps/kube-system/cilium/app/networks.yaml b/kubernetes/apps/kube-system/cilium/app/networks.yaml
index 0f60be4d..ca5cf624 100644
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -64,11 +64,11 @@ spec:
     matchLabels:
       kubernetes.io/os: linux
   bgpInstances:
-    - name: instance-64513
-      localASN: 64513
+    - name: instance-64514
+      localASN: 64514
       peers:
-        - name: peer-64514-v4
-          peerASN: 64514
+        - name: peer-64513-v4
+          peerASN: 64513
           peerAddress: 10.0.0.1
           peerConfigRef:
             name: bgp-peer-config-v4

$ kubectl apply -f networks.yaml

cilium-thkmp cilium-agent time="2025-04-22T15:41:38.630701299Z" level=info msg="Neighbor soft reset out" Key=10.0.0.1 Topic=Operation asn=64513 component=gobgp.BgpServerInstance subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.823915108Z" level=info msg="Delete a peer configuration" Key=10.0.0.1 Topic=Peer asn=64513 component=gobgp.BgpServerInstance subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.823960571Z" level=info msg="Removed BGP instance" instance=instance-64513 subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.823965835Z" level=info msg="Registering BGP instance" instance=instance-64514 subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824510873Z" level=info msg="Neighbor soft reset out" Key=10.0.0.1 Topic=Operation asn=64514 component=gobgp.BgpServerInstance subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824555409Z" level=info msg="Neighbor soft reset out" Key=10.0.0.1 Topic=Operation asn=64514 component=gobgp.BgpServerInstance subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824852915Z" level=info msg="Reconciling peers for instance" instance=instance-64514 reconciler=Neighbor subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824861825Z" level=info msg="Adding peer" instance=instance-64514 peer=peer-64513-v4 reconciler=Neighbor subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824900195Z" level=info msg="Add a peer configuration" Key=10.0.0.1 Topic=Peer asn=64514 component=gobgp.BgpServerInstance subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:38.824939979Z" level=info msg="Successfully registered BGP instance" instance=instance-64514 subsys=bgp-control-plane
cilium-thkmp cilium-agent time="2025-04-22T15:41:47.314495315Z" level=info msg="Peer Up" Key=10.0.0.1 State=BGP_FSM_OPENCONFIRM Topic=Peer asn=64514 component=gobgp.BgpServerInstance subsys=bgp-control-plane

$ cilium bgp peers
Node     Local AS   Peer AS   Peer Address   Session State   Uptime   Family         Received   Advertised
node01   64514      64513     10.0.0.1       established     2m23s    ipv4/unicast   14         2
```